### PR TITLE
fix param names and update go.mod/go.sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/insomniacslk/ingv
 
-go 1.20
+go 1.24
 
 require (
-	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.8.4
+	github.com/spf13/pflag v1.0.7
+	github.com/stretchr/testify v1.10.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
+github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/request.go
+++ b/request.go
@@ -14,7 +14,7 @@ import (
 )
 
 // time format used by the INGV API
-const TimeFormat = "2006-01-02T15:04:05.999999"
+const TimeFormat = "2006-01-02T15:04:05"
 
 var TimeLocation = time.UTC
 
@@ -38,8 +38,8 @@ type Request struct {
 	MinRadiusKm                 *float64   `name:"minradiuskm"`
 	MinDepth                    *float64   `name:"mindepth"`
 	MaxDepth                    *float64   `name:"maxdepth"`
-	StartTime                   *time.Time `name:"start_time"`
-	EndTime                     *time.Time `name:"end_time"`
+	StartTime                   *time.Time `name:"starttime"`
+	EndTime                     *time.Time `name:"endtime"`
 	MinMag                      *float64   `name:"minmag"`
 	MaxMag                      *float64   `name:"maxmag"`
 	MagnitudeType               *int       `name:"magnitudetype"`


### PR DESCRIPTION
hi! first of all nice work, thank you

it seems the API was changed at some point in the last two years and `start_time`, `end_time` parameters have become `starttime`, `endtime` according to https://webservices.ingv.it/swagger-ui/dist/?url=https://ingv.github.io/openapi/fdsnws/event/0.0.1/event.yaml, this fixes that (and removes sub-second units from the Timestamp layout), plus bumping the go mod/sum files along the way

<img width="1404" height="676" alt="image" src="https://github.com/user-attachments/assets/ca1413e4-22d1-4a72-a7a1-7bf805e8b545" />
